### PR TITLE
Remove idiomatic order

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,6 @@
 {
 	"extends": [
-		"stylelint-config-standard",
-		"stylelint-config-idiomatic-order"
+		"stylelint-config-standard"
 	],
 	"plugins": [
 		"stylelint-no-unsupported-browser-features",
@@ -15,6 +14,7 @@
 			"custom-properties",
 			"declarations"
 		],
+		"order/properties-alphabetical-order": true,
 		"indentation": "tab",
 		"no-eol-whitespace": [
 			true,

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
 		"prettier": "^2.2.1",
 		"style-dictionary": "^3.0.0",
 		"stylelint": "^13.13.0",
-		"stylelint-config-idiomatic-order": "^8.1.0",
 		"stylelint-config-standard": "^22.0.0",
 		"stylelint-no-unsupported-browser-features": "^5.0.1",
 		"stylelint-order": "^4.1.0",

--- a/src/atoms/label/Label.tsx
+++ b/src/atoms/label/Label.tsx
@@ -27,10 +27,10 @@ export default Label;
  * @category Styles
  */
 const StLabel = styled.label`
-	display: flex;
-	margin: 0 0 0.25rem;
 	color: #333;
+	display: flex;
 	font-weight: bold;
+	margin: 0 0 0.25rem;
 `;
 
 const StLabelSymbol = styled.i`

--- a/src/atoms/text-input/TextInput.tsx
+++ b/src/atoms/text-input/TextInput.tsx
@@ -43,9 +43,9 @@ export default TextInput;
  * @category Styles
  */
 const StTextInput = styled.input`
-	padding: 0.25rem;
-	border: 1px solid #ccc;
 	background: #fff;
+	border: 1px solid #ccc;
+	padding: 0.25rem;
 
 	&:disabled {
 		background: #ddd;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -32,13 +32,13 @@ type StProps = Partial<ButtonProps>;
 
 const StButton = styled.button(
 	({ small, variant }: StProps) => css`
-		min-width: ${tokens.buttonMinWidth};
-		height: 40px;
-		padding: 0 ${tokens.buttonHorizontalPadding};
 		border-radius: ${tokens.buttonBorderRadius};
 		cursor: pointer;
 		font-size: 1rem;
 		font-weight: bold;
+		height: 40px;
+		min-width: ${tokens.buttonMinWidth};
+		padding: 0 ${tokens.buttonHorizontalPadding};
 		transition-duration: ${tokens.transitionDuration};
 		transition-property: background-color, color;
 
@@ -61,23 +61,23 @@ const StButton = styled.button(
 		&:disabled,
 		&:disabled:hover,
 		&:disabled:active {
-			border: none;
 			background-color: ${tokens.buttonDisabledBgColor};
+			border: none;
 			color: ${tokens.buttonDisabledTextColor};
 			cursor: not-allowed;
 		}
 
 		${small &&
 		css`
-			min-width: ${tokens.buttonSmallMinWidth};
-			height: 30px;
 			font-size: 0.875rem;
+			height: 30px;
+			min-width: ${tokens.buttonSmallMinWidth};
 		`}
 
 		${variant === 'primary' &&
 		css`
-			border: none;
 			background-color: ${tokens.buttonPrimaryBgColor};
+			border: none;
 			color: ${tokens.buttonPrimaryTextColor};
 
 			&:hover {
@@ -91,8 +91,8 @@ const StButton = styled.button(
 
 		${variant === 'secondary' &&
 		css`
-			border: 1px solid ${tokens.buttonSecondaryBorderColor};
 			background-color: ${tokens.buttonSecondaryBgColor};
+			border: 1px solid ${tokens.buttonSecondaryBorderColor};
 			color: ${tokens.buttonSecondaryTextColor};
 
 			&:hover {
@@ -106,11 +106,11 @@ const StButton = styled.button(
 
 		${variant === 'link' &&
 		css`
+			background: none;
+			border: none;
+			color: ${tokens.buttonLinkTextColor};
 			min-width: initial;
 			padding: 0;
-			border: none;
-			background: none;
-			color: ${tokens.buttonLinkTextColor};
 
 			&:disabled,
 			&:disabled:hover,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12012,13 +12012,6 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-stylelint-config-idiomatic-order@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-idiomatic-order/-/stylelint-config-idiomatic-order-8.1.0.tgz#7ca7fa92eb79369948dd4977499466c844ace21d"
-  integrity sha512-iTPY6JjbkIdzy+21x3a1xi/tG33zKhLJb6lZl1xg6jZrXjgIYelnRZ5xVtbcEP9rElxZq/Zu1eGthfvI+ri+YQ==
-  dependencies:
-    stylelint-order "^3.1.1"
-
 stylelint-config-recommended@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz#fb5653f495a60b4938f2ad3e77712d9e1039ae78"
@@ -12039,15 +12032,6 @@ stylelint-no-unsupported-browser-features@^5.0.1:
     doiuse "^4.4.1"
     lodash "^4.17.15"
     postcss "^8.1.4"
-
-stylelint-order@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-3.1.1.tgz#ba9ea6844d1482f97f31204e7c9605c7b792c294"
-  integrity sha512-4gP/r8j/6JGZ/LL41b2sYtQqfwZl4VSqTp7WeIwI67v/OXNQ08dnn64BGXNwAUSgb2+YIvIOxQaMzqMyQMzoyQ==
-  dependencies:
-    lodash "^4.17.15"
-    postcss "^7.0.17"
-    postcss-sorting "^5.0.1"
 
 stylelint-order@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
We took the decision to revert to alpabetic sorting order because it's both easier to work with and there is no real benifit with the idiomatic order.