### PR TITLE
Feature/150 auto a11y tests

### DIFF
--- a/docs/adr/009-automatic-a11y-testing.md
+++ b/docs/adr/009-automatic-a11y-testing.md
@@ -1,0 +1,19 @@
+# Automatic accessibility testing
+
+`2021-07-07`
+
+## Status
+
+`✅ Accepted`
+
+## Context
+
+Since we don't know what end-users will be interacting with our components it is important that they meet accessibility standards from the start. We should test this in multiple ways, and automatic testing is one way. It does not cover all cases, but provide a safeguard against common and programmatically identifiable accessibility issues.
+
+## Decision
+
+We will test all of our components with the [Axe testing engine](https://github.com/dequelabs/axe-core).
+
+## Consequences
+
+The accessibility level of our components will be guaranteed to be higher than before.

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
 		'~components/(.*)': ['<rootDir>/src/components/$1'],
 		'~atoms/(.*)': ['<rootDir>/src/atoms/$1'],
 	},
+	setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,3 @@
+import { toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	"dependencies": {
 		"@emotion/react": "^11.4.0",
 		"@emotion/styled": "^11.3.0",
+		"@types/jest-axe": "^3.5.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},
@@ -65,6 +66,7 @@
 		"eslint-plugin-react": "^7.23.2",
 		"husky": "^6.0.0",
 		"jest": "^27.0.1",
+		"jest-axe": "^5.0.1",
 		"lint-staged": "^11.0.0",
 		"prettier": "^2.2.1",
 		"style-dictionary": "^3.0.0",

--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import React from 'react';
 import Button from './Button';
 
@@ -11,5 +12,11 @@ describe('Button', () => {
 		fireEvent.click(buttonElement);
 
 		expect(isClicked).toBe(true);
+	});
+
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<Button onClick={() => ({})}>I am button</Button>);
+
+		expect(await axe(container)).toHaveNoViolations();
 	});
 });

--- a/src/components/heading/Heading.test.tsx
+++ b/src/components/heading/Heading.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import React from 'react';
 import Heading, { HeadingLevel } from './Heading';
 
@@ -16,5 +17,11 @@ describe('Heading', () => {
 		const { container } = render(<Heading as="h1">I am heading</Heading>);
 
 		expect(container.querySelector('h1')?.innerHTML).toBe('I am heading');
+	});
+
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<Heading as="h1">I am heading</Heading>);
+
+		expect(await axe(container)).toHaveNoViolations();
 	});
 });

--- a/src/components/icon/Icon.test.tsx
+++ b/src/components/icon/Icon.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import React from 'react';
 import Icon from '~components/icon/Icon';
 import Icons from '~tokens/icons/Icons';
@@ -7,5 +8,11 @@ describe('Icon', () => {
 	test('The Icon component has SVG', () => {
 		const { container } = render(<Icon icon={Icons.Check} />);
 		expect(container.querySelector(`span svg`)).toBeTruthy();
+	});
+
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<Icon icon={Icons.Check} />);
+
+		expect(await axe(container)).toHaveNoViolations();
 	});
 });

--- a/src/components/input-text-field/InputTextField.test.tsx
+++ b/src/components/input-text-field/InputTextField.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
 import React from 'react';
 import InputTextField from '~components/input-text-field/InputTextField';
 
@@ -21,5 +22,11 @@ describe('InputTextField', () => {
 		);
 		const inputElement = getByLabelText('inputTextField') as HTMLInputElement;
 		expect(inputElement.type).toBe('text');
+	});
+
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<InputTextField label="inputTextField" id="myInputTextField" />);
+
+		expect(await axe(container)).toHaveNoViolations();
 	});
 });

--- a/src/components/loader/Loader.test.tsx
+++ b/src/components/loader/Loader.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import React from 'react';
+import Loader from '~components/loader/Loader';
+
+describe('Loader', () => {
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<Loader />);
+
+		expect(await axe(container)).toHaveNoViolations();
+	});
+});

--- a/src/components/loader/Loader.tsx
+++ b/src/components/loader/Loader.tsx
@@ -40,7 +40,7 @@ export default Loader;
  * @category Helpers
  */
 const getCircle = (cx: number, begin: number) => (
-	<circle fill={Colors.blueDark} stroke="none" cx={cx} cy="26" r="6">
+	<circle fill={Colors.blueDark} stroke="none" cx={cx} cy="26" r="6" key={cx}>
 		<animate
 			attributeName="opacity"
 			dur="1s"

--- a/src/components/progress-bar/ProgressBar.test.tsx
+++ b/src/components/progress-bar/ProgressBar.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import React from 'react';
 import ProgressBar from '~components/progress-bar/ProgressBar';
 
@@ -7,5 +8,11 @@ describe('ProgressBar', () => {
 		const { getByTitle } = render(<ProgressBar title="progress" value={10} />);
 		const element = getByTitle('progress');
 		expect(element.getAttribute('value')).toEqual('10');
+	});
+
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<ProgressBar title="progress" value={10} />);
+
+		expect(await axe(container)).toHaveNoViolations();
 	});
 });

--- a/src/components/row/Row.test.tsx
+++ b/src/components/row/Row.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import React from 'react';
 import Row from '~components/row/Row';
 
@@ -12,5 +13,16 @@ describe('Row', () => {
 		);
 
 		expect(container.querySelectorAll('.child').length).toBe(2);
+	});
+
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(
+			<Row>
+				<div className="child"></div>
+				<div className="child"></div>
+			</Row>
+		);
+
+		expect(await axe(container)).toHaveNoViolations();
 	});
 });

--- a/src/components/spacer/Spacer.test.tsx
+++ b/src/components/spacer/Spacer.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import React from 'react';
+import Spacer from '~components/spacer/Spacer';
+import Spacings from '~tokens/spacings/Spacings';
+
+describe('Loader', () => {
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<Spacer spacing={Spacings.md} />);
+
+		expect(await axe(container)).toHaveNoViolations();
+	});
+});

--- a/src/components/text-area-field/TextAreaField.test.tsx
+++ b/src/components/text-area-field/TextAreaField.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
 import React from 'react';
 import TextAreaField from '~components/text-area-field/TextAreaField';
 
@@ -13,5 +14,11 @@ describe('TextAreaField', () => {
 		userEvent.type(textArea, 'testing');
 
 		expect(textArea.value).toBe('testing');
+	});
+
+	test('It passes automatic accesibility tests', async () => {
+		const { container } = render(<TextAreaField label="inputTextField" id="myInputTextField" />);
+
+		expect(await axe(container)).toHaveNoViolations();
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,7 +3056,15 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.23":
+"@types/jest-axe@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-axe/-/jest-axe-3.5.1.tgz#122c3864e361c8d699e60814a6a7f6851101d263"
+  integrity sha512-yelGgELc6iJEPShJ3/XEu6uUr5rCGi/Md0QzMuoo53y0WpR2lyFM3mjdpo8Q+PPd3onHOpIw6BBzEAIU65ZFSA==
+  dependencies:
+    "@types/jest" "*"
+    axe-core "^3.5.5"
+
+"@types/jest@*", "@types/jest@^26.0.23":
   version "26.0.23"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
   integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
@@ -3975,6 +3983,16 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axe-core@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
+  integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
+
+axe-core@^3.5.5:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.6.tgz#e762a90d7f6dbd244ceacb4e72760ff8aad521b5"
+  integrity sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==
+
 axe-core@^4.0.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
@@ -4646,6 +4664,14 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
@@ -8275,6 +8301,16 @@ java-properties@^1.0.0:
   resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
   integrity sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==
 
+jest-axe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jest-axe/-/jest-axe-5.0.1.tgz#26c43643b2e5f2bd4900c1ab36f8283635957a6e"
+  integrity sha512-MMOWA6gT4pcZGbTLS8ZEqABH08Lnj5bInfLPpn9ADWX2wFF++odbbh8csmSfkwKjHaioVPzlCtIypAtxFDx/rw==
+  dependencies:
+    axe-core "4.2.1"
+    chalk "4.1.0"
+    jest-matcher-utils "27.0.2"
+    lodash.merge "4.6.2"
+
 jest-changed-files@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.0.6.tgz#bed6183fcdea8a285482e3b50a9a7712d49a7a8b"
@@ -8364,7 +8400,7 @@ jest-diff@^26.0.0:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-diff@^27.0.6:
+jest-diff@^27.0.2, jest-diff@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.0.6.tgz#4a7a19ee6f04ad70e0e3388f35829394a44c7b5e"
   integrity sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==
@@ -8422,7 +8458,7 @@ jest-get-type@^26.3.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
-jest-get-type@^27.0.6:
+jest-get-type@^27.0.1, jest-get-type@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
   integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
@@ -8499,6 +8535,16 @@ jest-leak-detector@^27.0.6:
   dependencies:
     jest-get-type "^27.0.6"
     pretty-format "^27.0.6"
+
+jest-matcher-utils@27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz#f14c060605a95a466cdc759acc546c6f4cbfc4f0"
+  integrity sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.0.2"
+    jest-get-type "^27.0.1"
+    pretty-format "^27.0.2"
 
 jest-matcher-utils@^27.0.6:
   version "27.0.6"
@@ -9166,7 +9212,7 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.merge@^4.6.2:
+lodash.merge@4.6.2, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==


### PR DESCRIPTION
A new jest setup file is required to make the assertions work in the tests (without having to import and define the assertion in every individual test).

Two components had no tests (reasonably so) but now they at least have a11y tests. Unclear if they can ever break, but we'll know if they do.

Closes #150 