### PR TITLE
Feature/171 tsdoc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,9 +19,10 @@
 		"ecmaVersion": 12,
 		"sourceType": "module"
 	},
-	"plugins": ["@typescript-eslint", "jsx-a11y", "react", "jest-dom"],
+	"plugins": ["@typescript-eslint", "jsx-a11y", "react", "jest-dom", "eslint-plugin-tsdoc"],
 	"rules": {
-		"@typescript-eslint/explicit-module-boundary-types": "off"
+		"@typescript-eslint/explicit-module-boundary-types": "off",
+		"tsdoc/syntax": "warn"
 	},
 	"settings": {
 		"react": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"eslint-plugin-jest-dom": "^3.9.0",
 		"eslint-plugin-jsx-a11y": "^6.4.1",
 		"eslint-plugin-react": "^7.23.2",
+		"eslint-plugin-tsdoc": "^0.2.14",
 		"husky": "^6.0.0",
 		"jest": "^27.0.1",
 		"jest-axe": "^5.0.1",

--- a/src/molecules/text-area-field/TextAreaField.tsx
+++ b/src/molecules/text-area-field/TextAreaField.tsx
@@ -63,9 +63,11 @@ export interface TextAreaFieldProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * TextAreaField component
+ * TextAreaField
  *
- * @see {@link https://skf.invisionapp.com/dsm/ab-skf/4-web-applications/nav/5fa7caf78c01200018354495/asset/5ea69e3b60bb930a70de53bd | DSM Documentation}
+ * This component renders a text area with corresponding label and other functionality, to be used in a form.
+ * For more information, @see {@link https://skf.invisionapp.com/dsm/ab-skf/4-web-applications/nav/5fa7caf78c01200018354495/asset/5ea69e3b60bb930a70de53bd | DSM Documentation}
+ *
  * @beta
  */
 const TextAreaField = forwardRef(

--- a/src/molecules/text-area-field/TextAreaField.tsx
+++ b/src/molecules/text-area-field/TextAreaField.tsx
@@ -5,22 +5,68 @@ import Label, { LabelProps } from '~atoms/label/Label';
 import TextArea, { TextAreaProps } from '~atoms/text-area/TextArea';
 import Colors from '~tokens/colors/Colors';
 
-/**
- * @category Props
- */
 export interface TextAreaFieldProps extends HTMLAttributes<HTMLDivElement> {
-	id: string;
-	label: string;
+	/**
+	 * If provided, this text will appear under the label
+	 */
 	description?: string;
+
+	/**
+	 * If true, the input will be non-interactable
+	 */
 	disabled?: boolean;
+
+	/**
+	 * This id will connect the internal TextArea and its Label
+	 *
+	 * @remarks
+	 * The id must be unique on the page
+	 *
+	 * @see {@link TextArea}
+	 * @see {@link Label}
+	 */
+	id: string;
+
+	/**
+	 * This text will display above the input field
+	 */
+	label: string;
+
+	/**
+	 * These LabelProps will be passed on to the internal Label
+	 *
+	 * @see {@link LabelProps}
+	 * @see {@link Label}
+	 */
 	labelProps?: LabelProps;
+
+	/**
+	 * If true, the input will be set to be required and a visual indicator will appear
+	 */
 	required?: boolean;
+
+	/**
+	 * These TextAreaProps will be passed on to the internal TextArea
+	 *
+	 * @see {@link TextAreaProps}
+	 * @see {@link TextArea}
+	 */
 	textAreaProps?: Partial<TextAreaProps>;
+
+	/**
+	 * Sets the value of the TextArea.
+	 *
+	 * @remarks This prop will make the component controlled and so you must provide an onChange handler
+	 * @see {@link https://reactjs.org/docs/forms.html#controlled-components}
+	 */
 	value?: string;
 }
 
 /**
- * @category Template
+ * TextAreaField component
+ *
+ * @see {@link https://skf.invisionapp.com/dsm/ab-skf/4-web-applications/nav/5fa7caf78c01200018354495/asset/5ea69e3b60bb930a70de53bd | DSM Documentation}
+ * @beta
  */
 const TextAreaField = forwardRef(
 	(
@@ -50,9 +96,6 @@ const TextAreaField = forwardRef(
 TextAreaField.displayName = 'TextAreaField';
 export default TextAreaField;
 
-/**
- * @category Styles
- */
 type StyledTextAreaFieldProps = Pick<TextAreaFieldProps, 'disabled'>;
 
 const StyledTextAreaField = styled.div(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,6 +1755,21 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
+"@microsoft/tsdoc-config@0.15.2":
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz#eb353c93f3b62ab74bdc9ab6f4a82bcf80140f14"
+  integrity sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==
+  dependencies:
+    "@microsoft/tsdoc" "0.13.2"
+    ajv "~6.12.6"
+    jju "~1.4.0"
+    resolve "~1.19.0"
+
+"@microsoft/tsdoc@0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz#3b0efb6d3903bd49edb073696f60e90df08efb26"
+  integrity sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -3641,7 +3656,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -6280,6 +6295,14 @@ eslint-plugin-react@^7.23.2:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-tsdoc@^0.2.14:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.14.tgz#e32e7c1df8af7b3009c252590bec07a1030afbf2"
+  integrity sha512-fJ3fnZRsdIoBZgzkQjv8vAj6NeeOoFkTfgosj6mKsFjX70QV256sA/wq+y/R2+OL4L8E79VVaVWrPeZnKNe8Ng==
+  dependencies:
+    "@microsoft/tsdoc" "0.13.2"
+    "@microsoft/tsdoc-config" "0.15.2"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -7937,6 +7960,13 @@ is-ci@^3.0.0:
   dependencies:
     ci-info "^3.1.1"
 
+is-core-module@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
+  integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
+  dependencies:
+    has "^1.0.3"
+
 is-core-module@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
@@ -8858,6 +8888,11 @@ jest@^27.0.1:
     "@jest/core" "^27.0.6"
     import-local "^3.0.2"
     jest-cli "^27.0.6"
+
+jju@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=
 
 js-string-escape@^1.0.1:
   version "1.0.1"
@@ -11643,6 +11678,14 @@ resolve@^2.0.0-next.3:
   integrity sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==
   dependencies:
     is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
+resolve@~1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:


### PR DESCRIPTION
Ok, so here we have a proposal for how we can document our components using TSDoc. You will notice a few things:
- Most of the documentation is in the interface. This makes it kind of huge, line wise, but this style of documentation is not uncommon in projects around the web.
- There aren't any section comments (like "here is the start of the 'styles' section of the file"). I couldn't find a nice way to do this that with TSDoc that didn't bleed into what the user was seeing. It can still be done with regular comments, but I also feel that if all our files follow the same structure (interface, component, styles) then it won't be a problem to find what we're looking for.

Using this kind of docs do the following:
- Storybook automatically picks up the comments and so we won't have to manually write "description" fields for every story.
- When a user of the component hovers over the component or any of its props they can see the docs in their editor, and can follow any links or read examples right there.
- If we want to we can extract the docs into a separate html page, but I don't see a need for this at this time.

So, things to have an opinion on:
**TSDoc**: yay or nay
**Section comments**: yay or nay

If yay, then I'll add docs for all our existing components and update this PR to be ready for review.